### PR TITLE
fix: support older iOS 13 dates

### DIFF
--- a/Sources/Topsort-Analytics/Models.swift
+++ b/Sources/Topsort-Analytics/Models.swift
@@ -77,7 +77,7 @@ struct Event : Codable {
     /**
      RFC3339 formatted timestamp including UTC offset.
      */
-    let ocurredAt: Date
+    let occurredAt: String
     
     /**
      The opaque user ID allows correlating user activity, such as Impressions, Clicks and Purchases, whether or not they
@@ -101,18 +101,18 @@ struct Event : Codable {
     
     let placement: Placement?
 
-    init(entity: Entity, ocurredAt: Date, opaqueUserId: String, placement: Placement? = nil) {
+    init(entity: Entity, occurredAt: String, opaqueUserId: String, placement: Placement? = nil) {
         self.entity = entity
-        self.ocurredAt = ocurredAt
+        self.occurredAt = occurredAt
         self.opaqueUserId = opaqueUserId
         self.resolvedBidId = nil
         self.placement = placement
         self.id = UUID()
     }
     
-    init(resolvedBidId: String, ocurredAt: Date, opaqueUserId: String, placement: Placement? = nil) {
+    init(resolvedBidId: String, occurredAt: String, opaqueUserId: String, placement: Placement? = nil) {
         self.entity = nil
-        self.ocurredAt = ocurredAt
+        self.occurredAt = occurredAt
         self.opaqueUserId = opaqueUserId
         self.resolvedBidId = resolvedBidId
         self.placement = placement
@@ -141,7 +141,7 @@ struct PurchaseEvent : Codable {
     /**
      RFC3339 formatted timestamp, including UTC offset, of the instant in which the order was placed.
      */
-    let ocurrentAt: Date
+    let occurredAt: String
     
     /**
      The opaque user ID allows correlating user activity, such as Impressions, Clicks and Purchases, whether or not they

--- a/Tests/analytics.swiftTests/analytics_swiftTests.swift
+++ b/Tests/analytics.swiftTests/analytics_swiftTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Analytics
+@testable import Topsort_Analytics
 
 final class analytics_swiftTests: XCTestCase {
     func testExample() throws {
@@ -11,7 +11,12 @@ final class analytics_swiftTests: XCTestCase {
     }
     
     func testEncodeModels() throws {
-        let myEvent = Event(entity: Entity(type: EntityType.product, id: "product-id"), ocurredAt: Date.now, opaqueUserId: "user-id")
+        let date = Date()
+        let iso8601DateFormatter = ISO8601DateFormatter()
+        iso8601DateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let occurredAt = iso8601DateFormatter.string(from: date)
+
+        let myEvent = Event(entity: Entity(type: EntityType.product, id: "product-id"), occurredAt: occurredAt, opaqueUserId: "user-id")
         let jsonEncoder = JSONEncoder()
         let jsonDecoder = JSONDecoder()
         jsonEncoder.dateEncodingStrategy = .iso8601


### PR DESCRIPTION
`Date.now` was introduced in iOS 15.

Also, fix build by changing the import and fix a typo for `occurredAt`.

Edit: Perhaps we make a util for dates that makes it easier to pass?