### PR TITLE
fix: correct AuctionCategory.disjunctions type from [String] to [[String]]

### DIFF
--- a/Sources/Topsort/Models/Auctions.swift
+++ b/Sources/Topsort/Models/Auctions.swift
@@ -27,11 +27,13 @@ public struct AuctionCategory: Codable, Equatable {
 
     /**
      * An array of disjunctions.
-     * In order to participate in an auction, a bid product must belong to at least one of the categories for each of the disjunctions provided in the auction request.
+     * In order to participate in an auction, a bid product must belong to at least one of the categories
+     * for each of the disjunctions provided in the auction request.
+     * Each disjunction is an array of category IDs (max 5 elements per disjunction).
      */
-    let disjunctions: [String]?
+    let disjunctions: [[String]]?
 
-    public init(id: String? = nil, ids: [String]? = nil, disjunctions: [String]? = nil) {
+    public init(id: String? = nil, ids: [String]? = nil, disjunctions: [[String]]? = nil) {
         self.id = id
         self.ids = ids
         self.disjunctions = disjunctions

--- a/Tests/topsort.swiftTests/models_swiftTests.swift
+++ b/Tests/topsort.swiftTests/models_swiftTests.swift
@@ -140,12 +140,15 @@ class EventModelTests: XCTestCase {
     }
 
     func testAuctionCategoryWithIds() throws {
-        let category = AuctionCategory(ids: ["c1", "c2"], disjunctions: ["d1"])
+        let category = AuctionCategory(ids: ["c1", "c2"], disjunctions: [["d1", "d2"], ["d3"]])
         let data = try JSONEncoder().encode(category)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         XCTAssertEqual((json["ids"] as? [String])?.count, 2)
-        XCTAssertEqual((json["disjunctions"] as? [String])?.count, 1)
+        let disjunctions = try XCTUnwrap(json["disjunctions"] as? [[String]])
+        XCTAssertEqual(disjunctions.count, 2)
+        XCTAssertEqual(disjunctions[0], ["d1", "d2"])
+        XCTAssertEqual(disjunctions[1], ["d3"])
     }
 
     func testAuctionResponseDecoding() throws {


### PR DESCRIPTION
## Summary
Fix `AuctionCategory.disjunctions` type from `[String]` to `[[String]]`.

The OpenAPI spec defines disjunctions as an array of arrays — each disjunction is a list of category IDs that a product must match at least one of. The flat `[String]` type produced invalid API requests.

**Breaking change**: callers using `disjunctions` must update from `["d1"]` to `[["d1"]]`.

## Test plan
- [x] `swift test` — 139 tests pass
- [x] `swiftformat .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)