### PR TITLE
feat: add event model parity and pageview events

### DIFF
--- a/Sources/Topsort/EventManager.swift
+++ b/Sources/Topsort/EventManager.swift
@@ -24,10 +24,10 @@ extension [EventItem] {
             }
         }
         return Events(
-            impressions: impressions,
-            clicks: clicks,
-            purchases: purchases,
-            pageviews: pageviews
+            impressions: impressions.isEmpty ? nil : impressions,
+            clicks: clicks.isEmpty ? nil : clicks,
+            purchases: purchases.isEmpty ? nil : purchases,
+            pageviews: pageviews.isEmpty ? nil : pageviews
         )
     }
 }

--- a/Sources/Topsort/EventManager.swift
+++ b/Sources/Topsort/EventManager.swift
@@ -6,24 +6,29 @@ enum EventItem: Codable {
     case click(Event)
     case impression(Event)
     case purchase(PurchaseEvent)
+    case pageview(PageViewEvent)
 }
 
 extension [EventItem] {
     func toEvents() -> Events {
-        let (i, c, p) = reduce(([], [], []), Self.agg)
-        return Events(impressions: i, clicks: c, purchases: p)
-    }
-
-    private static func agg(r: ([Event], [Event], [PurchaseEvent]), e: EventItem) -> ([Event], [Event], [PurchaseEvent]) {
-        let (i, c, p) = r
-        switch e {
-        case let .click(event):
-            return (i, c + [event], p)
-        case let .impression(event):
-            return (i + [event], c, p)
-        case let .purchase(event):
-            return (i, c, p + [event])
+        var impressions: [Event] = []
+        var clicks: [Event] = []
+        var purchases: [PurchaseEvent] = []
+        var pageviews: [PageViewEvent] = []
+        for item in self {
+            switch item {
+            case let .impression(event): impressions.append(event)
+            case let .click(event): clicks.append(event)
+            case let .purchase(event): purchases.append(event)
+            case let .pageview(event): pageviews.append(event)
+            }
         }
+        return Events(
+            impressions: impressions,
+            clicks: clicks,
+            purchases: purchases,
+            pageviews: pageviews
+        )
     }
 }
 

--- a/Sources/Topsort/Models/Events.swift
+++ b/Sources/Topsort/Models/Events.swift
@@ -73,18 +73,63 @@ public struct Entity: Codable {
 }
 
 /// Page context for pageview events and auction requests.
+/// Valid page types: "home", "category", "PDP", "search", "cart", "other".
 public struct Page: Codable {
-    /// The type of page (e.g. "category", "product", "search", "home").
-    let type: String
+    /// The type of page (e.g. "category", "product", "search", "home", "cart").
+    public let type: String
     /// An identifier for the page (required by the API).
-    let pageId: String
-    /// A value associated with the page (e.g. category name, search query).
-    let value: String?
+    public let pageId: String
+    /// A single value (e.g. category name, search query) or an array of values
+    /// (e.g. product IDs for cart pages). The API accepts either format under the `value` key.
+    public let value: PageValue?
 
     public init(type: String, pageId: String, value: String? = nil) {
         self.type = type
         self.pageId = pageId
-        self.value = value
+        self.value = value.map { .string($0) }
+    }
+
+    public init(type: String, pageId: String, values: [String]) {
+        self.type = type
+        self.pageId = pageId
+        value = .array(values)
+    }
+}
+
+/// A page value that can be either a single string or an array of strings.
+public enum PageValue: Codable {
+    case string(String)
+    case array([String])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let s = try? container.decode(String.self) {
+            self = .string(s)
+        } else if let arr = try? container.decode([String].self) {
+            self = .array(arr)
+        } else {
+            throw DecodingError.typeMismatch(PageValue.self, .init(codingPath: decoder.codingPath, debugDescription: "Expected String or [String]"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .string(s): try container.encode(s)
+        case let .array(arr): try container.encode(arr)
+        }
+    }
+
+    /// Convenience: get the string value (nil if array).
+    public var stringValue: String? {
+        if case let .string(s) = self { return s }
+        return nil
+    }
+
+    /// Convenience: get the array value (nil if string).
+    public var arrayValue: [String]? {
+        if case let .array(arr) = self { return arr }
+        return nil
     }
 }
 
@@ -281,6 +326,13 @@ struct Events: Codable {
     let clicks: [Event]?
     let purchases: [PurchaseEvent]?
     let pageviews: [PageViewEvent]?
+
+    init(impressions: [Event]? = nil, clicks: [Event]? = nil, purchases: [PurchaseEvent]? = nil, pageviews: [PageViewEvent]? = nil) {
+        self.impressions = impressions
+        self.clicks = clicks
+        self.purchases = purchases
+        self.pageviews = pageviews
+    }
 
     init(impressions: [Event], clicks: [Event]? = nil, purchases: [PurchaseEvent]? = nil, pageviews: [PageViewEvent]? = nil) {
         self.impressions = impressions

--- a/Sources/Topsort/Models/Events.swift
+++ b/Sources/Topsort/Models/Events.swift
@@ -76,12 +76,12 @@ public struct Entity: Codable {
 public struct Page: Codable {
     /// The type of page (e.g. "category", "product", "search", "home").
     let type: String
-    /// An identifier for the page.
-    let pageId: String?
+    /// An identifier for the page (required by the API).
+    let pageId: String
     /// A value associated with the page (e.g. category name, search query).
     let value: String?
 
-    public init(type: String, pageId: String? = nil, value: String? = nil) {
+    public init(type: String, pageId: String, value: String? = nil) {
         self.type = type
         self.pageId = pageId
         self.value = value
@@ -120,6 +120,9 @@ public struct Event: Codable {
 
     let placement: Placement?
 
+    /// Page context for the event.
+    let page: Page?
+
     /// Device type: "desktop" or "mobile".
     let deviceType: String?
 
@@ -137,6 +140,7 @@ public struct Event: Codable {
         occurredAt: Date,
         opaqueUserId: String = Topsort.shared.opaqueUserId,
         placement: Placement? = nil,
+        page: Page? = nil,
         deviceType: String? = nil,
         channel: String? = nil,
         additionalAttribution: Entity? = nil,
@@ -147,6 +151,7 @@ public struct Event: Codable {
         self.opaqueUserId = opaqueUserId
         resolvedBidId = nil
         self.placement = placement
+        self.page = page
         self.deviceType = deviceType
         self.channel = channel
         self.additionalAttribution = additionalAttribution
@@ -159,6 +164,7 @@ public struct Event: Codable {
         occurredAt: Date,
         opaqueUserId: String = Topsort.shared.opaqueUserId,
         placement: Placement? = nil,
+        page: Page? = nil,
         deviceType: String? = nil,
         channel: String? = nil,
         additionalAttribution: Entity? = nil,
@@ -169,6 +175,7 @@ public struct Event: Codable {
         self.opaqueUserId = opaqueUserId
         self.resolvedBidId = resolvedBidId
         self.placement = placement
+        self.page = page
         self.deviceType = deviceType
         self.channel = channel
         self.additionalAttribution = additionalAttribution

--- a/Sources/Topsort/Models/Events.swift
+++ b/Sources/Topsort/Models/Events.swift
@@ -72,6 +72,22 @@ public struct Entity: Codable {
     }
 }
 
+/// Page context for pageview events and auction requests.
+public struct Page: Codable {
+    /// The type of page (e.g. "category", "product", "search", "home").
+    let type: String
+    /// An identifier for the page.
+    let pageId: String?
+    /// A value associated with the page (e.g. category name, search query).
+    let value: String?
+
+    public init(type: String, pageId: String? = nil, value: String? = nil) {
+        self.type = type
+        self.pageId = pageId
+        self.value = value
+    }
+}
+
 public struct Event: Codable {
     /**
      The entity associated with the promotable over which the interaction occurred.
@@ -88,15 +104,12 @@ public struct Event: Codable {
     /**
      The opaque user ID allows correlating user activity, such as Impressions, Clicks and Purchases, whether or not they
      are actually logged in. It must be long lived (at least a year) so that Topsort can attribute purchases.
-
-     If your users are always logged in you may use a hash of your customer ID. If your users may interact with your app or site while logged out we recommend generating a random identifier (UUIDv4) on first load and store it on local storage (cookie, local storage, etc) and let it live for at least a year.
      */
     let opaqueUserId: String
 
     /**
      The marketplace's unique ID for the impression. This field ensures the event reporting is idempotent in case there is
-     a network issue and the request is retried. If there is no impression model on the marketplace side, generate a unique
-     string that does not change if the event is resent.
+     a network issue and the request is retried.
      */
     let id: UUID
 
@@ -107,21 +120,59 @@ public struct Event: Codable {
 
     let placement: Placement?
 
-    public init(entity: Entity, occurredAt: Date, opaqueUserId: String = Topsort.shared.opaqueUserId, placement: Placement? = nil) {
+    /// Device type: "desktop" or "mobile".
+    let deviceType: String?
+
+    /// Channel: "onsite", "offsite", or "instore".
+    let channel: String?
+
+    /// Additional entity for halo attribution. Requires resolvedBidId to be set.
+    let additionalAttribution: Entity?
+
+    /// Click type: "product", "like", or "add-to-cart". Only applicable for click events.
+    let clickType: String?
+
+    public init(
+        entity: Entity,
+        occurredAt: Date,
+        opaqueUserId: String = Topsort.shared.opaqueUserId,
+        placement: Placement? = nil,
+        deviceType: String? = nil,
+        channel: String? = nil,
+        additionalAttribution: Entity? = nil,
+        clickType: String? = nil
+    ) {
         self.entity = entity
         self.occurredAt = occurredAt
         self.opaqueUserId = opaqueUserId
         resolvedBidId = nil
         self.placement = placement
+        self.deviceType = deviceType
+        self.channel = channel
+        self.additionalAttribution = additionalAttribution
+        self.clickType = clickType
         id = UUID()
     }
 
-    public init(resolvedBidId: String, occurredAt: Date, opaqueUserId: String = Topsort.shared.opaqueUserId, placement: Placement? = nil) {
+    public init(
+        resolvedBidId: String,
+        occurredAt: Date,
+        opaqueUserId: String = Topsort.shared.opaqueUserId,
+        placement: Placement? = nil,
+        deviceType: String? = nil,
+        channel: String? = nil,
+        additionalAttribution: Entity? = nil,
+        clickType: String? = nil
+    ) {
         entity = nil
         self.occurredAt = occurredAt
         self.opaqueUserId = opaqueUserId
         self.resolvedBidId = resolvedBidId
         self.placement = placement
+        self.deviceType = deviceType
+        self.channel = channel
+        self.additionalAttribution = additionalAttribution
+        self.clickType = clickType
         id = UUID()
     }
 }
@@ -136,10 +187,14 @@ public struct PurchaseItem: Codable {
     /// The price of a single item in the marketplace currency.
     let unitPrice: Double
 
-    public init(productId: String, unitPrice: Double, quantity: Int? = nil) {
+    /// The vendor ID for halo attribution.
+    let vendorId: String?
+
+    public init(productId: String, unitPrice: Double, quantity: Int? = nil, vendorId: String? = nil) {
         self.productId = productId
         self.quantity = quantity
         self.unitPrice = unitPrice
+        self.vendorId = vendorId
     }
 }
 
@@ -151,27 +206,65 @@ public struct PurchaseEvent: Codable {
     var occurredAt: Date
 
     /**
-     The opaque user ID allows correlating user activity, such as Impressions, Clicks and Purchases, whether or not they
-     are actually logged in. It must be long lived (at least a year) so that Topsort can attribute purchases.
-
-     If your users are always logged in you may use a hash of your customer ID. If your users may interact with your app or
-     site while logged out we recommend generating a random identifier (UUIDv4) on first load and store it on local storage
-     (cookie, local storage, etc) and let it live for at least a year.
+     The opaque user ID allows correlating user activity.
      */
     let opaqueUserId: String
 
     let items: [PurchaseItem]
 
     /**
-     The marketplace unique ID for the order. This field ensures the event reporting is idempotent in case there is a
-     network issue and the request is retried. If there is no unique ID for orders on the marketplace side, generate a
-     unique string that does not change if the event needs to be resent.
+     The marketplace unique ID for the order. Ensures idempotent event reporting.
      */
     let id: UUID
-    public init(items: [PurchaseItem], occurredAt: Date, opaqueUserId: String = Topsort.shared.opaqueUserId) {
+
+    /// Device type: "desktop" or "mobile".
+    let deviceType: String?
+
+    /// Channel: "onsite", "offsite", or "instore".
+    let channel: String?
+
+    public init(
+        items: [PurchaseItem],
+        occurredAt: Date,
+        opaqueUserId: String = Topsort.shared.opaqueUserId,
+        deviceType: String? = nil,
+        channel: String? = nil
+    ) {
         self.items = items
         self.occurredAt = occurredAt
         self.opaqueUserId = opaqueUserId
+        self.deviceType = deviceType
+        self.channel = channel
+        id = UUID()
+    }
+}
+
+/// A page view event for tracking navigation.
+public struct PageViewEvent: Codable {
+    @TSDateValue
+    var occurredAt: Date
+    let opaqueUserId: String
+    let id: UUID
+    let page: Page
+
+    /// Device type: "desktop" or "mobile".
+    let deviceType: String?
+
+    /// Channel: "onsite", "offsite", or "instore".
+    let channel: String?
+
+    public init(
+        page: Page,
+        occurredAt: Date,
+        opaqueUserId: String = Topsort.shared.opaqueUserId,
+        deviceType: String? = nil,
+        channel: String? = nil
+    ) {
+        self.page = page
+        self.occurredAt = occurredAt
+        self.opaqueUserId = opaqueUserId
+        self.deviceType = deviceType
+        self.channel = channel
         id = UUID()
     }
 }
@@ -180,22 +273,33 @@ struct Events: Codable {
     let impressions: [Event]?
     let clicks: [Event]?
     let purchases: [PurchaseEvent]?
+    let pageviews: [PageViewEvent]?
 
-    init(impressions: [Event], clicks: [Event]? = nil, purchases: [PurchaseEvent]? = nil) {
+    init(impressions: [Event], clicks: [Event]? = nil, purchases: [PurchaseEvent]? = nil, pageviews: [PageViewEvent]? = nil) {
         self.impressions = impressions
         self.clicks = clicks
         self.purchases = purchases
+        self.pageviews = pageviews
     }
 
-    init(clicks: [Event], impressions: [Event]? = nil, purchases: [PurchaseEvent]? = nil) {
+    init(clicks: [Event], impressions: [Event]? = nil, purchases: [PurchaseEvent]? = nil, pageviews: [PageViewEvent]? = nil) {
         self.impressions = impressions
         self.clicks = clicks
         self.purchases = purchases
+        self.pageviews = pageviews
     }
 
-    init(purchases: [PurchaseEvent], impressions: [Event]? = nil, clicks: [Event]? = nil) {
+    init(purchases: [PurchaseEvent], impressions: [Event]? = nil, clicks: [Event]? = nil, pageviews: [PageViewEvent]? = nil) {
         self.impressions = impressions
         self.clicks = clicks
         self.purchases = purchases
+        self.pageviews = pageviews
+    }
+
+    init(pageviews: [PageViewEvent], impressions: [Event]? = nil, clicks: [Event]? = nil, purchases: [PurchaseEvent]? = nil) {
+        self.impressions = impressions
+        self.clicks = clicks
+        self.purchases = purchases
+        self.pageviews = pageviews
     }
 }

--- a/Sources/Topsort/Topsort.swift
+++ b/Sources/Topsort/Topsort.swift
@@ -13,6 +13,11 @@ public protocol TopsortProtocol {
     func executeAuctions(auctions: [Auction]) async throws(AuctionError) -> AuctionResponse
 }
 
+/// Default implementation for backward compatibility with existing conformers.
+public extension TopsortProtocol {
+    func track(pageview _: PageViewEvent) {}
+}
+
 public class Topsort: TopsortProtocol {
     public static let shared = Topsort()
     public internal(set) var isConfigured = false

--- a/Sources/Topsort/Topsort.swift
+++ b/Sources/Topsort/Topsort.swift
@@ -8,6 +8,7 @@ public protocol TopsortProtocol {
     func track(impression event: Event)
     func track(click event: Event)
     func track(purchase event: PurchaseEvent)
+    func track(pageview event: PageViewEvent)
     func flush()
     func executeAuctions(auctions: [Auction]) async throws(AuctionError) -> AuctionResponse
 }
@@ -77,6 +78,14 @@ public class Topsort: TopsortProtocol {
             return
         }
         EventManager.shared.push(event: .purchase(event))
+    }
+
+    public func track(pageview event: PageViewEvent) {
+        guard isConfigured else {
+            Logger.warning("track(pageview:) called before configure(). Event dropped.")
+            return
+        }
+        EventManager.shared.push(event: .pageview(event))
     }
 
     public func flush() {

--- a/Tests/banners.swiftTests/bannerView_swiftTests.swift
+++ b/Tests/banners.swiftTests/bannerView_swiftTests.swift
@@ -210,6 +210,7 @@ private class FailingMockTopsort: TopsortProtocol {
     func track(impression _: Event) {}
     func track(click _: Event) {}
     func track(purchase _: PurchaseEvent) {}
+    func track(pageview _: PageViewEvent) {}
     func flush() {}
     func executeAuctions(auctions _: [Auction]) async throws(AuctionError) -> AuctionResponse {
         throw .emptyResponse

--- a/Tests/banners.swiftTests/mocks/analyticsMock.swift
+++ b/Tests/banners.swiftTests/mocks/analyticsMock.swift
@@ -10,18 +10,14 @@ public class MockTopsort: TopsortProtocol {
     public var trackedImpressions: [Event] = []
     public var trackedClicks: [Event] = []
     public var trackedPurchases: [PurchaseEvent] = []
+    public var trackedPageviews: [PageViewEvent] = []
 
     public init(executeAuctionsMockResponse: AuctionResponse) {
         self.executeAuctionsMockResponse = executeAuctionsMockResponse
     }
 
-    public func set(opaqueUserId _: String?) {
-        // Mock implementation
-    }
-
-    public func configure(_: Configuration) throws {
-        // Mock implementation
-    }
+    public func set(opaqueUserId _: String?) {}
+    public func configure(_: Configuration) throws {}
 
     public func track(impression event: Event) {
         trackedImpressions.append(event)
@@ -35,9 +31,11 @@ public class MockTopsort: TopsortProtocol {
         trackedPurchases.append(event)
     }
 
-    public func flush() {
-        // Mock implementation
+    public func track(pageview event: PageViewEvent) {
+        trackedPageviews.append(event)
     }
+
+    public func flush() {}
 
     public func executeAuctions(auctions _: [Auction]) async throws(AuctionError) -> AuctionResponse {
         executeAuctionsMockResponse


### PR DESCRIPTION
## Summary
Add missing event fields from the OpenAPI spec and introduce pageview events:

| Model | New Fields | Purpose |
|-------|-----------|---------|
| `Event` | `deviceType`, `channel`, `additionalAttribution`, `clickType` | Device context, halo attribution, click types |
| `PurchaseEvent` | `deviceType`, `channel` | Device/channel context |
| `PurchaseItem` | `vendorId` | Halo attribution |
| **`PageViewEvent`** (new) | `page`, `occurredAt`, `opaqueUserId`, `deviceType`, `channel` | Track page navigation |
| **`Page`** (new) | `type`, `pageId`, `value` | Page context |

Also adds:
- `EventItem.pageview` case in EventManager
- `track(pageview:)` on `TopsortProtocol` and `Topsort`
- `pageviews` array in `Events` batch struct

All new fields optional — backward compatible.

## Stack
Stacked on #45 (`feat/auction-model-parity`).

## Test plan
- [x] `swift test` — 139 tests pass
- [x] `swiftformat .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)