### PR TITLE
feat: add missing auction model fields for API parity

### DIFF
--- a/Sources/Topsort/Models/Auctions.swift
+++ b/Sources/Topsort/Models/Auctions.swift
@@ -63,9 +63,8 @@ public struct AuctionProducts: Codable, Equatable {
 public struct Auction: Codable, Equatable {
     /**
      * Discriminator for the type of auction.
-     * Could be one of the following values:
-     * - "listings"
-     * - "banner"
+     * - "listings" — Sponsored listings auction
+     * - "banners" — Banner ad auction
      */
     let type: String
 
@@ -76,6 +75,7 @@ public struct Auction: Codable, Equatable {
 
     /**
      * The ID of the banner placement for which this auction will be run for.
+     * Required for banner auctions.
      */
     let slotId: String?
 
@@ -94,6 +94,16 @@ public struct Auction: Codable, Equatable {
     let searchQuery: String?
     let geoTargeting: AuctionGeoTargeting?
 
+    /**
+     * An opaque user identifier for auction targeting context.
+     */
+    let opaqueUserId: String?
+
+    /**
+     * Unique identifier for the placement where the auction result will be displayed.
+     */
+    let placementId: String?
+
     public init(
         type: String,
         slots: Int,
@@ -102,7 +112,9 @@ public struct Auction: Codable, Equatable {
         products: AuctionProducts? = nil,
         category: AuctionCategory? = nil,
         searchQuery: String? = nil,
-        geoTargeting: AuctionGeoTargeting? = nil
+        geoTargeting: AuctionGeoTargeting? = nil,
+        opaqueUserId: String? = nil,
+        placementId: String? = nil
     ) {
         self.type = type
         self.slots = slots
@@ -112,13 +124,24 @@ public struct Auction: Codable, Equatable {
         self.searchQuery = searchQuery
         self.category = category
         self.products = products
+        self.opaqueUserId = opaqueUserId
+        self.placementId = placementId
     }
 }
 
 // Auctions response models
 
+public struct AssetContent: Codable {
+    public let headingText: String?
+    public let bannerText: String?
+    public let bannerTextColour: String?
+    public let heroImage: String?
+    public let heroImageAltText: String?
+}
+
 public struct Asset: Codable {
     public let url: String
+    public let content: AssetContent?
 }
 
 public struct Winner: Codable {
@@ -127,6 +150,7 @@ public struct Winner: Codable {
     public let type: String
     public let id: String
     public let resolvedBidId: String
+    public let campaignId: String?
 }
 
 public struct AuctionResult: Codable {

--- a/Sources/Topsort/Models/Auctions.swift
+++ b/Sources/Topsort/Models/Auctions.swift
@@ -139,7 +139,45 @@ public struct Asset: Codable {
 
     /// Flexible content fields for banner templates.
     /// Keys and values vary per marketplace configuration.
+    /// The API schema allows arbitrary JSON values (additionalProperties: true),
+    /// so non-string values are converted to their string representation.
     public let content: [String: String]?
+
+    public init(url: String, content: [String: String]? = nil) {
+        self.url = url
+        self.content = content
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        url = try container.decode(String.self, forKey: .url)
+        // Lenient decoding: skip non-string values instead of crashing
+        if let raw = try? container.decodeIfPresent([String: LenientStringValue].self, forKey: .content) {
+            content = raw.compactMapValues(\.value)
+        } else {
+            content = nil
+        }
+    }
+}
+
+/// Decodes any JSON primitive as a String, returning nil for non-decodable values.
+private struct LenientStringValue: Decodable {
+    let value: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let s = try? container.decode(String.self) {
+            value = s
+        } else if let i = try? container.decode(Int.self) {
+            value = String(i)
+        } else if let d = try? container.decode(Double.self) {
+            value = String(d)
+        } else if let b = try? container.decode(Bool.self) {
+            value = String(b)
+        } else {
+            value = nil
+        }
+    }
 }
 
 public struct Winner: Codable {

--- a/Sources/Topsort/Models/Auctions.swift
+++ b/Sources/Topsort/Models/Auctions.swift
@@ -102,7 +102,7 @@ public struct Auction: Codable, Equatable {
     /**
      * Unique identifier for the placement where the auction result will be displayed.
      */
-    let placementId: String?
+    let placementId: Int?
 
     public init(
         type: String,
@@ -114,7 +114,7 @@ public struct Auction: Codable, Equatable {
         searchQuery: String? = nil,
         geoTargeting: AuctionGeoTargeting? = nil,
         opaqueUserId: String? = nil,
-        placementId: String? = nil
+        placementId: Int? = nil
     ) {
         self.type = type
         self.slots = slots
@@ -131,17 +131,12 @@ public struct Auction: Codable, Equatable {
 
 // Auctions response models
 
-public struct AssetContent: Codable {
-    public let headingText: String?
-    public let bannerText: String?
-    public let bannerTextColour: String?
-    public let heroImage: String?
-    public let heroImageAltText: String?
-}
-
 public struct Asset: Codable {
     public let url: String
-    public let content: AssetContent?
+
+    /// Flexible content fields for banner templates.
+    /// Keys and values vary per marketplace configuration.
+    public let content: [String: String]?
 }
 
 public struct Winner: Codable {

--- a/Sources/Topsort/Models/Auctions.swift
+++ b/Sources/Topsort/Models/Auctions.swift
@@ -100,7 +100,10 @@ public struct Auction: Codable, Equatable {
     let opaqueUserId: String?
 
     /**
-     * Unique identifier for the placement where the auction result will be displayed.
+     * Experiment bucket identifier (1-8) used for A/B testing in conjunction
+     * with the Topsort Data Science team. Assigns the auction request to one
+     * of up to 8 buckets to enable controlled experiments on auction behavior.
+     * Not related to banner slot placement — use `slotId` for that.
      */
     let placementId: Int?
 

--- a/Tests/banners.swiftTests/bannerView_swiftTests.swift
+++ b/Tests/banners.swiftTests/bannerView_swiftTests.swift
@@ -22,8 +22,8 @@ class TopsortBannerTests: XCTestCase {
 
     func testExecuteAuctions() async throws {
         // Mock the response
-        let asset = Asset(url: "https://example.com")
-        let winner = Winner(rank: 1, asset: [asset], type: "type", id: "id", resolvedBidId: "resolved_bid_id")
+        let asset = Asset(url: "https://example.com", content: nil)
+        let winner = Winner(rank: 1, asset: [asset], type: "type", id: "id", resolvedBidId: "resolved_bid_id", campaignId: nil)
         let auctionResult = AuctionResult(resultType: "result_type", winners: [winner], error: false)
         let auctionResponse = AuctionResponse(results: [auctionResult])
 
@@ -50,8 +50,8 @@ class TopsortBannerTests: XCTestCase {
     }
 
     func testExecuteAuctionsDoesNotTrackImpression() async throws {
-        let asset = Asset(url: "https://example.com")
-        let winner = Winner(rank: 1, asset: [asset], type: "type", id: "id", resolvedBidId: "bid-id")
+        let asset = Asset(url: "https://example.com", content: nil)
+        let winner = Winner(rank: 1, asset: [asset], type: "type", id: "id", resolvedBidId: "bid-id", campaignId: nil)
         let auctionResult = AuctionResult(resultType: "result_type", winners: [winner], error: false)
         let auctionResponse = AuctionResponse(results: [auctionResult])
 
@@ -165,7 +165,7 @@ class TopsortBannerTests: XCTestCase {
     // MARK: - ViewModel edge cases
 
     func testViewModelWinnerWithNoAsset() async throws {
-        let winner = Winner(rank: 1, asset: nil, type: "type", id: "id", resolvedBidId: "bid")
+        let winner = Winner(rank: 1, asset: nil, type: "type", id: "id", resolvedBidId: "bid", campaignId: nil)
         let auctionResult = AuctionResult(resultType: "result_type", winners: [winner], error: false)
         let auctionResponse = AuctionResponse(results: [auctionResult])
 


### PR DESCRIPTION
## Summary
Add fields from the OpenAPI spec:
- Auction: `opaqueUserId`, `placementId` (experiment bucket 1-8)
- Winner: `campaignId`
- Asset: `content` as `[String: String]?` with lenient decoding for non-string values

All optional, backward compatible.

## Test plan
- [x] `swift test` passes
- [x] `swiftformat .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)