### PR TITLE
chore(ci): remove codecov integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,3 @@ jobs:
           XCTEST="$BIN/TopsortPackageTests.xctest/Contents/MacOS/TopsortPackageTests"
           PROFDATA=$(find .build -name 'default.profdata' -type f)
           xcrun llvm-cov export "$XCTEST" -instr-profile="$PROFDATA" -format=lcov > coverage.lcov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.lcov
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: Topsort/topsort.swift
-          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # topsort.swift
 
 [![Build](https://github.com/Topsort/topsort.swift/actions/workflows/test.yml/badge.svg)](https://github.com/Topsort/topsort.swift/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/Topsort/topsort.swift/branch/main/graph/badge.svg)](https://codecov.io/gh/Topsort/topsort.swift)
 [![Swift 5.3+](https://img.shields.io/badge/Swift-5.3+-orange.svg)](https://swift.org)
 [![Platforms](https://img.shields.io/badge/Platforms-iOS%2015+%20|%20macOS%2012+%20|%20tvOS%2011+%20|%20watchOS%207.1+-blue.svg)](https://github.com/Topsort/topsort.swift)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)


### PR DESCRIPTION
We weren't really using this and the recent changes in ownership made us to reassess the usage of Codecov.
